### PR TITLE
Adding ability to write simulated oifits files

### DIFF
--- a/oitools.jl
+++ b/oitools.jl
@@ -5,3 +5,4 @@ include("oiplot.jl");
 include("vis_functions_classic.jl");
 include("modelfit.jl");
 include("write_oifits_ha.jl");
+include("write_oifits_obs.jl");

--- a/simulate_obs.jl
+++ b/simulate_obs.jl
@@ -1,0 +1,204 @@
+using FITSIO.Libcfitsio;
+using OIFITS
+include("../OITOOLS.jl/oitools.jl");
+using NFFT;
+
+
+#NEED TO ADD ABILTY TO HAVE DIFFERENT INSNAME IN OUTPUT IF IN PUT HAS DIFFERENT INSNAME...basically just copy and pass header.
+oifitsin="AZCYG2014FINALMOD.oifits";
+
+
+#oifitsin="test1.oifits";
+data = (readoifits(oifitsin))[1,1]; # data can be split by wavelength, time, etc.
+oifits=FITS(oifitsin);
+
+
+
+#setup simulation
+
+nuv = data.nuv
+fitsfile = "simtest.fits";
+pixsize=0.1
+x = (read((FITS(fitsfile))[1])); x=x[:,end:-1:1]; nx = (size(x))[1]; x=vec(x)/sum(x);
+
+
+#nfft_plan = setup_nfft(-uv, nx, pixsize)
+#cvis_model = image_to_cvis_nfft(x, nfft_plan)
+
+dft = setup_dft(data.uv, nx, pixsize);
+cvis_model = image_to_cvis_dft(x, dft);
+
+
+#setup new file
+outfilename ="!testcopy.oifits"
+f = fits_create_file(outfilename);
+copy_oi_header(f,oifits[1]);
+
+
+
+
+ioiarraytables=[]
+swavetables=[]
+iwavetables=[]
+svistables=[]
+ivistables=[]
+st3tables=[]
+it3tables=[]
+for itable=2:length(oifits)
+    if (read_key(oifits[itable],"EXTNAME")[1] == "OI_ARRAY")
+        push!(ioiarraytables,itable)
+    end
+    if (read_key(oifits[itable],"EXTNAME")[1] == "OI_WAVELENGTH")
+        push!(swavetables,read_key(oifits[itable],"INSNAME")[1])
+        push!(iwavetables,itable)
+    end
+    if (read_key(oifits[itable],"EXTNAME")[1] == "OI_VIS2")
+        push!(svistables,read_key(oifits[itable],"INSNAME")[1])
+        push!(ivistables,itable)
+    end
+    if (read_key(oifits[itable],"EXTNAME")[1] == "OI_T3")
+        push!(st3tables,read_key(oifits[itable],"INSNAME")[1])
+        push!(it3tables,itable)
+    end
+end
+#TO GET OTHER PIECES OF INFO
+
+
+#get OI_ARRY details (currently only handles one Array)
+for itable=1:length(ioiarraytables)
+    telnames=read(oifits[ioiarraytables[itable]],"TEL_NAME")
+    sta_names=read(oifits[ioiarraytables[itable]],"STA_NAME")
+    sta_index=read(oifits[ioiarraytables[itable]],"STA_INDEX")
+    tel_diams= read(oifits[ioiarraytables[itable]],"DIAMETER")
+    staxyz=read(oifits[ioiarraytables[itable]],"STAXYZ");
+    station_xyz=transpose(staxyz);
+    N=length(read(oifits[ioiarraytables[itable]],"TEL_NAME"))
+    oi_array=[telnames,sta_names,sta_index,tel_diams,staxyz];
+    copy_oi_array(f,oifits[ioiarraytables[itable]],oi_array);
+end
+
+#get target array details
+
+target_id=read(oifits["OI_TARGET"],"TARGET_ID");
+target=read(oifits["OI_TARGET"],"TARGET");
+raep0=read(oifits["OI_TARGET"],"RAEP0");
+decep0=read(oifits["OI_TARGET"],"DECEP0");
+equinox=read(oifits["OI_TARGET"],"EQUINOX");
+ra_err=read(oifits["OI_TARGET"],"RA_ERR");
+dec_err=read(oifits["OI_TARGET"],"DEC_ERR");
+sysvel=-read(oifits["OI_TARGET"],"SYSVEL");
+veltyp=read(oifits["OI_TARGET"],"VELTYP");
+veldef=read(oifits["OI_TARGET"],"VELDEF");
+pmra=read(oifits["OI_TARGET"],"PMRA");
+pmdec=read(oifits["OI_TARGET"],"PMDEC");
+pmra_err=read(oifits["OI_TARGET"],"PMRA_ERR");
+pmdec_err=read(oifits["OI_TARGET"],"PMDEC_ERR");
+parallax=read(oifits["OI_TARGET"],"PARALLAX"); #COULD PULL FROM GAIA
+para_err=read(oifits["OI_TARGET"],"PARA_ERR");
+spectyp=read(oifits["OI_TARGET"],"SPECTYP");
+target_array=[target_id,target,raep0,decep0,equinox,ra_err,dec_err,sysvel,veltyp,veldef,pmra,pmdec,pmra_err,pmdec_err,parallax,para_err,spectyp];
+copy_oi_target(f,oifits[ioiarraytables[length(ioiarraytables)]+1],target_array);
+
+
+
+#GET WAVE TABLES
+for itable=1:length(iwavetables)
+    eff_wave=read(oifits[iwavetables[itable]],"EFF_WAVE")
+    eff_band=read(oifits[iwavetables[itable]],"EFF_BAND")
+    wave_array=[eff_wave,eff_band];
+    copy_oi_wavelength(f,oifits[iwavetables[itable]],wave_array);
+end
+
+#GET V2 INFO
+
+
+v2_model = cvis_to_v2(cvis_model, data.indx_v2 )# based on uv points
+#v2_model_err=data.v2_err
+v2_model_err=v2_model/(data.v2/data.v2_errß)
+v2_model += v2_model_err.*randn(length(v2_model))
+#Now to fill the tables_
+#uvis_lam=[];
+#vvis_lam=[];
+#v2_stations=[];
+visindxstart=1
+for itable=1:length(ivistables); #for each table
+    v2_model_table=[]
+    v2_model_err_table=[]
+    uvis=read(oifits[ivistables[itable]],"UCOORD");
+    vvis=read(oifits[ivistables[itable]],"VCOORD")
+    wavetablenum=iwavetables[find(swavetables.==svistables[itable])]
+    eff_wave= read(oifits[wavetablenum[1]],"EFF_WAVE")
+    eff_band = read(oifits[wavetablenum[1]],"EFF_BAND")
+    nw=length(eff_wave);
+    for hour=1:length(uvis)
+        for wave=1:nw
+            v2_model_table=push!(v2_model_table,v2_model[visindxstart+wave-1]);
+            v2_model_err_table=push!(v2_model_err_table,v2_model_err[visindxstart+wave-1]);
+        end
+        visindxstart=visindxstart+nw
+    end
+    target_id_vis2=read(oifits[ivistables[itable]],"TARGET_ID");
+    time_vis2=read(oifits[ivistables[itable]],"TIME");
+    mjd_vis2=read(oifits[ivistables[itable]],"MJD");
+    int_time_vis2=read(oifits[ivistables[itable]],"INT_TIME");
+    v2_model_stations=read(oifits[ivistables[itable]],"STA_INDEX");
+    nrowvis=Int(length(v2_model_table)/nw)
+    v2_model_reshape=reshape(v2_model_table,(nw,nrowvis));
+    v2_model_err_reshape=reshape(v2_model_err_table,(nw,nrowvis));
+    flag_vis2=read(oifits[ivistables[itable]],"FLAG")
+    vis2_array=[target_id_vis2,time_vis2,mjd_vis2,int_time_vis2,v2_model_reshape,v2_model_err_reshape,uvis,vvis,v2_model_stations,flag_vis2'];
+    copy_oi_vis2(f,oifits[ivistables[itable]],vis2_array);
+end
+
+#GET T3 NOW
+t3_model, t3amp_model, t3phi_model = cvis_to_t3(cvis_model, data.indx_t3_1, data.indx_t3_2, data.indx_t3_3);
+
+
+#t3amp_model_err =0.007*t3amp_model+1e-6
+#t3amp_model_err=data.t3amp_err
+t3amp_model_err=t3amp_model/(data.t3amp/data.t3amp_err)
+t3amp_model += t3amp_model_err.*randn(length(t3amp_model))
+
+#t3phi_model_err = zeros(length(t3phi_model))+2. # degree  -- there is another way of setting this with Haniff formula
+#t3phi_model_err=data.t3phi_err
+t3phi_model_err=t3phi_model/(data.t3phi/data.t3phi_err)
+t3phi_model += t3phi_model_err.*randn(length(t3phi_model))
+
+t3indxstart=1
+for itable=1:length(it3tables); #for each table
+    t3amp_model_table=[]
+    t3amp_model_err_table=[]
+    t3phi_model_table=[]
+    t3phi_model_err_table=[]
+    u1=read(oifits[it3tables[itable]],"U1COORD");
+    v1=read(oifits[it3tables[itable]],"V1COORD")
+    u2=read(oifits[it3tables[itable]],"U2COORD");
+    v2=read(oifits[it3tables[itable]],"V2COORD")
+    wavetablenum=iwavetables[find(swavetables.==st3tables[itable])]
+    eff_wave= read(oifits[wavetablenum[1]],"EFF_WAVE")
+    eff_band = read(oifits[wavetablenum[1]],"EFF_BAND")
+    nw=length(eff_wave);
+    for hour=1:length(u1)
+        for wave=1:nw
+            t3amp_model_table=push!(t3amp_model_table,t3amp_model[t3indxstart+wave-1]);
+            t3amp_model_err_table=push!(t3amp_model_err_table,t3amp_model_err[t3indxstart+wave-1]);
+            t3phi_model_table=push!(t3phi_model_table,t3phi_model[t3indxstart+wave-1]);
+            t3phi_model_err_table=push!(t3phi_model_err_table,t3phi_model_err[t3indxstart+wave-1]);
+        end
+        t3indxstart=t3indxstart+nw
+    end
+    target_id_t3=read(oifits[it3tables[itable]],"TARGET_ID");
+    time_t3=read(oifits[it3tables[itable]],"TIME");
+    mjd_t3=read(oifits[it3tables[itable]],"MJD");
+    int_time_t3=read(oifits[it3tables[itable]],"INT_TIME");
+    t3_model_stations=read(oifits[it3tables[itable]],"STA_INDEX");
+    nrowt3=Int(length(t3amp_model_table)/nw)
+    t3amp_model_reshape=reshape(t3amp_model_table,(nw,nrowt3));
+    t3amp_model_err_reshape=reshape(t3amp_model_err_table,(nw,nrowt3));
+    t3phi_model_reshape=reshape(t3phi_model_table,(nw,nrowt3));
+    t3phi_model_err_reshape=reshape(t3phi_model_err_table,(nw,nrowt3));
+    flag_t3=read(oifits[it3tables[itable]],"FLAG")
+    t3_array=[target_id_t3,time_t3,mjd_t3,int_time_t3,t3amp_model_reshape,t3amp_model_err_reshape,t3phi_model_reshape,t3phi_model_err_reshape,u1,v1,u2,v2,t3_model_stations,flag_t3'];
+    copy_oi_t3(f,oifits[it3tables[itable]],t3_array);
+end
+fits_close_file(f)

--- a/write_oifits_obs.jl
+++ b/write_oifits_obs.jl
@@ -1,0 +1,346 @@
+using FITSIO.Libcfitsio;
+using OIFITS;
+
+#=
+function get_extname(filein)
+    num=fits_get_num_hdus(filein)
+    extnames=Array{String}(num)
+    for i=1:num
+      hdu_type=fits_movabs_hdu(filein,i)
+      if hdu_type ==:binary_table
+        extnames[i]=fits_read_keyword(filein,"EXTNAME")[1]
+      else
+        extnames[i]="NONE"
+      end
+    end
+    return extnames
+  end
+
+function find_hdu_from_extname(extname_array,extname_name)
+   indx=find(extname_array->extname_array==extname_name,extname_array)
+  return indx
+end
+
+
+function make_header_cfitsio(header,fileout)
+  for i=1:length(header)
+    fits_write_key(fileout,keys(header)[i],values(header)[i],get_comment(keys(header)[i]));
+  end
+end
+
+function copy_oifits(fileout,filein)
+    fts = FITS(filein)
+    copy_oi_header(fileout,exten,fts)
+    length(fts)       #number of hdu
+    for i=2:length
+        hdr = FITSIO.read_header(fts[i]])
+end
+
+function copycols(fileout,hduin)
+    colnames=FITSIO.colnames(hduin)
+    for i=1:length(colnames)
+        col=FITSIO.read(hduin,colnames(i))
+        fits_write_col(fileout, i, 1, 1, col;
+    end
+end
+=#
+
+function copy_oi_header(fileout,hduin) #filenone in this case is in FITSIO not cfitsio
+  #= Make header. Based on John Young's code =#
+  #Move to primary HDU
+  if fits_get_num_hdus(fileout) == 0
+    fits_create_img(fileout,Int16,zeros(Int64,0)); #Create primary HDU if it doesn't exist
+  else
+    fits_movabs_hdu(fileout,1);  #Move to primary HDU
+  end
+  header=FITSIO.read_header(hduin);
+  nkeys=length(header)
+    for i = 4:nkeys #first four are created by create_img
+        entry = FITSIO.read_key(hduin,i);
+        if typeof(entry[2]) != Void
+            fits_write_key(fileout,entry[1],entry[2],entry[3]);
+        else
+        fits_write_key(fileout,entry[1],"",entry[3]);
+        end
+    end
+ end
+
+function copy_oi_array(fileout,hduin,arrays)
+
+  #=
+  Writing the OI_WAVELENGTH binary table
+  based on cfitsio and John Young's oifitslib
+  =#
+  header=FITSIO.read_header(hduin);
+  tfields = 5;
+  ttype= ["TEL_NAME", "STA_NAME", "STA_INDEX", "DIAMETER", "STAXYZ"]#,"FOV", "FOVTYPE"];
+  tform = ["16A", "16A", "I", "E", "3D"]#, "D", "6A"];
+  tunit = ["\0", "\0", "\0", "m", "m"]# "arcsec", ""];
+  extname = header["EXTNAME"];
+  extver = header["EXTVER"]
+  revision = header["OI_REVN"]; #1 or 2 depending on which format XYZ
+  arrname=header["ARRNAME"]
+  frame=header["FRAME"]
+  arrayx=header["ARRAYX"]
+  arrayy=header["ARRAYY"]
+  arrayz=header["ARRAYZ"]
+  coldefs = [(ttype[1],tform[1],tunit[1]),(ttype[2],tform[2],tunit[2]),(ttype[3],tform[3],tunit[3]),
+          (ttype[4],tform[4],tunit[4]),(ttype[5],tform[5],tunit[5])];
+          #= OFITS2 needs to add ,(ttype[6],tform[6],tunit[6]),(ttype[7],tform[7],tunit[7])];=#
+  fits_create_binary_tbl(fileout,0,coldefs,extname);
+  fits_write_key(fileout,"EXTNAME",extname,"name of the binary extension")
+  fits_write_key(fileout,"EXTEND",extver,"Extension version");
+  fits_write_key(fileout,"OI_REVN",revision,"Revision number of the table definition");
+  fits_write_key(fileout,"ARRNAME",arrname,"Array Name");
+  fits_write_key(fileout,"FRAME",frame,"Coordinate Frame");
+  fits_write_key(fileout,"ARRAYX",arrayx,"[m] Array center x coordinate");
+  fits_write_key(fileout,"ARRAYY",arrayy,"[m] Array center y coordinate");
+  fits_write_key(fileout,"ARRAYZ",arrayz,"[m] Array center z coordinate");
+  fits_write_col(fileout, 1, 1, 1, convert(Array{String},arrays[1]));
+  fits_write_col(fileout, 2, 1, 1, convert(Array{String},arrays[2]));
+  fits_write_col(fileout, 3, 1, 1, convert(Array{Int16},arrays[3]));
+  fits_write_col(fileout, 4, 1, 1, convert(Array{Float32},arrays[4]));
+  fits_write_col(fileout, 5, 1, 1, convert(Array{Float64,2},arrays[5]));
+#= OIFITS2 STUFF
+int revision = 2, irow;
+  fits_write_key(fptr, TSTRING, "ARRNAOI_VIS2 ME", array.arrname,
+                 "Array name", pStatus);
+  fits_write_key(fptr, TSTRING, "FRAME", array.frame,
+                 "Coordinate frame", pStatus);
+  fits_write_key(fptr, TDOUBLE, "ARRAYX", &array.arrayx,
+                 "Array centre x coordinate", pStatus);
+  fits_write_key_unit(fptr, "ARRAYX", "m", pStatus);
+  fits_write_key(fptr, TDOUBLE, "ARRAYY", &array.arrayy,
+                 "Array centre y coordinate", pStatus);
+  fits_write_key_unit(fptr, "ARRAYY", "m", pStatus);
+  fits_write_key(fptr, TDOUBLE, "ARRAYZ", &array.arrayz,
+                 "Array centre z coordinate", pStatus);
+  fits_write_key_unit(fptr, "ARRAYZ", "m", pStatus);
+  fits_write_key(fptr, TINT, "EXTVER", &extver,
+"ID number of this OI_ARRAY", pStatus);=#
+#  irows=size(OIFITS.select(oifilein,"OI_ARRAY"))[1]
+
+  #OIFITS2 needs additional columns which might be more difficult as OIFITS doesn't have the get procedures for those yet
+    #if error status ==1 return 0; this is an error check I might put in later
+ end
+
+
+function copy_oi_target(fileout,hduin,arrays)
+  #=
+  /**
+   * Write OI_TARGET fits binary table
+   */=#
+  header=FITSIO.read_header(hduin);
+  tfields = 17;
+  ttype = ["TARGET_ID", "TARGET", "RAEP0", "DECEP0", "EQUINOX",
+                   "RA_ERR", "DEC_ERR", "SYSVEL", "VELTYP",
+                   "VELDEF", "PMRA", "PMDEC", "PMRA_ERR", "PMDEC_ERR",
+                   "PARALLAX", "PARA_ERR", "SPECTYP"];
+  tform = ["I", "16A", "D", "D", "E",
+                   "D", "D", "D", "8A",
+                   "8A", "D", "D", "D", "D",
+                   "E", "E", "16A"];
+  tunit = ["\0", "\0", "deg", "deg", "yr",
+                   "deg", "deg", "m/s", "\0",
+                   "\0", "deg/yr", "deg/yr", "deg/yr", "deg/yr",
+                   "deg", "deg", "\0"];
+  extname = header["EXTNAME"];
+  revision =header["OI_REVN"] ;
+  coldefs =[(ttype[1],tform[1],tunit[1]),(ttype[2],tform[2],tunit[2]),(ttype[3],tform[3],tunit[3]),
+          (ttype[4],tform[4],tunit[4]),(ttype[5],tform[5],tunit[5]),(ttype[6],tform[6],tunit[6]),
+          (ttype[7],tform[7],tunit[7]),(ttype[8],tform[8],tunit[8]),(ttype[9],tform[9],tunit[9]),
+          (ttype[10],tform[10],tunit[10]),(ttype[11],tform[11],tunit[11]),(ttype[12],tform[12],tunit[12]),
+          (ttype[13],tform[13],tunit[13]),(ttype[14],tform[14],tunit[14]),(ttype[15],tform[15],tunit[15]),
+          (ttype[16],tform[16],tunit[16]),(ttype[17],tform[17],tunit[17])];
+  fits_create_binary_tbl(fileout,0,coldefs,extname);
+  fits_write_key(fileout,"EXTNAME",extname,"name of the binary extension")
+  fits_write_key(fileout,"OI_REVN",revision,"Revision number of the table definition");
+  fits_write_col(fileout, 1, 1, 1,  convert(Array{Int16},arrays[1]));
+  fits_write_col(fileout, 2, 1, 1,  convert(Array{String},arrays[2]));
+  fits_write_col(fileout, 3, 1, 1,  convert(Array{Float64},arrays[3]));
+  fits_write_col(fileout, 4, 1, 1,  convert(Array{Float64},arrays[4]));
+  fits_write_col(fileout, 5, 1, 1,  convert(Array{Float32},arrays[5]));
+  fits_write_col(fileout, 6, 1, 1,  convert(Array{Float64},arrays[6]));
+  fits_write_col(fileout, 7, 1, 1,  convert(Array{Float64},arrays[7]));
+  fits_write_col(fileout, 8, 1, 1,  convert(Array{Float64},arrays[8]));
+  fits_write_col(fileout, 9, 1, 1,  convert(Array{String},arrays[9]));
+  fits_write_col(fileout, 10, 1, 1, convert(Array{String},arrays[10]));
+  fits_write_col(fileout, 11, 1, 1, convert(Array{Float64},arrays[11]));
+  fits_write_col(fileout, 12, 1, 1, convert(Array{Float64},arrays[12]));
+  fits_write_col(fileout, 13, 1, 1, convert(Array{Float64},arrays[13]));
+  fits_write_col(fileout, 14, 1, 1, convert(Array{Float64},arrays[14]));
+  fits_write_col(fileout, 15, 1, 1, convert(Array{Float32},arrays[15]));
+  fits_write_col(fileout, 16, 1, 1, convert(Array{Float32},arrays[16]));
+  fits_write_col(fileout, 17, 1, 1, convert(Array{String},arrays[17]));
+  #fits_write_key(fileout,"EXTEND",extver,"Extension version");
+  #= OIFITS2 Stuff
+  int revision = 2, irow
+  OIFITS2 needs additional columns which might be more difficult as OIFITS doesn't have the get procedures for those yet =#
+  #if error status ==1 return 0; this is an error check I might put in later
+ end
+
+function copy_oi_wavelength(fileout,hduin,arrays)
+  #=
+  Writing the OI_WAVELENGTH binary table
+  based on cfitsio and John Young's oifitslib
+  =#
+  header=FITSIO.read_header(hduin);
+  tfields = 2;
+  ttype= ["EFF_WAVE", "EFF_BAND"];
+  tform= ["1E", "1E"];
+  tunit = ["m", "m"];
+  extname = header["EXTNAME"];
+  extver = header["EXTVER"]
+  revision = header["OI_REVN"]; #1 or 2 depending on which format XYZ
+  insname=header["INSNAME"]
+
+  coldefs =[(ttype[1],tform[1],tunit[1]),(ttype[2],tform[2],tunit[2])];
+  fits_create_binary_tbl(fileout,0,coldefs,extname);
+  fits_write_key(fileout,"EXTNAME",extname,"name of the binary extension")
+  fits_write_key(fileout,"EXTEND",extver,"Extension version")
+ fits_write_key(fileout,"INSNAME",insname,"Name of detector, for cross-referencing");
+  fits_write_key(fileout,"OI_REVN",revision,"Revision number of the table definition");
+
+  #=OIFITS2 STUFF
+  CHECK REVISION? if (wave.revision != revision) { printf("WARNING! wave.revision != %d on entry to %s. ""Writing revision %d table\n", revision, function, revision);}
+  FITSIO.Libcfitsio.fits_write_key(fout,"OI_REVN", revision,"Revision number of the table definition");
+  FITSIO.Libcfitsio.fits_write_key(fout, "INSNAME", wave.insname,"Detector name");
+  FITSIO.Libcfitsio.fits_write_key(fout,"EXTVER",extver,"ID number of this OI_WAVELENGTH"); #Normally 1 it seems
+    #if error status ==1 return 0; this is an error check I might put in later
+  #nwave=size(OIFITS.select(oifilein,"OI_WAVELENGTH"))[1]#
+=#
+
+  fits_write_col(fileout, 1, 1, 1, convert(Array{Float32},arrays[1]));
+  fits_write_col(fileout, 2, 1, 1, convert(Array{Float32},arrays[2]));
+ end
+
+
+function copy_oi_vis2(fileout,hduin,arrays)
+#=
+/**
+ * Write OI_VIS2 fits binary table
+ *
+ * @param fptr     see cfitsio documentation
+ * @param vis2     data struct, see exchange.h
+ * @param extver   value for EXTVER keyword
+ * @param pStatus  pointer to status variable
+ *
+ * @return On error, returns non-zero cfitsio error code, and sets *pStatus
+ */
+=#
+  header=FITSIO.read_header(hduin);
+  tfields = 10;  # mandatory columns */
+  zerotime = 0.0;
+  nw=size(arrays[5])[1]
+  ttype = ["TARGET_ID", "TIME", "MJD", "INT_TIME",
+           "VIS2DATA", "VIS2ERR", "UCOORD", "VCOORD",
+           "STA_INDEX", "FLAG"];
+  #tform = ["1I", "1D", "1D", "1D",
+    #       "8D", "8D", "1D", "1D",
+    #        "2I", "8L"];
+    tform = ["1I", "1D", "1D", "1D",
+             "$(nw)D", "$(nw)D", "1D", "1D",
+             "2I", "$(nw)L"];
+  tunit = ["\0", "s", "day", "s",
+            "\0", "\0", "m", "m",
+            "\0", "\0"];
+  date_obs  = string(Dates.today())
+  date_obs = header["DATE-OBS"]
+  arrname = header["ARRNAME"]
+  extname = header["EXTNAME"];
+  extver = header["EXTVER"]
+  revision = header["OI_REVN"]; #1 or 2 depending on which format XYZ
+  insname=header["INSNAME"]
+  coldefs =[(ttype[1],tform[1],tunit[1]),(ttype[2],tform[2],tunit[2]),(ttype[3],tform[3],tunit[3]),
+          (ttype[4],tform[4],tunit[4]),(ttype[5],tform[5],tunit[5]),(ttype[6],tform[6],tunit[6]),
+          (ttype[7],tform[7],tunit[7]),(ttype[8],tform[8],tunit[8]),(ttype[9],tform[9],tunit[9]),
+          (ttype[10],tform[10],tunit[10])];
+  fits_create_binary_tbl(fileout,0,coldefs,extname);
+ fits_write_key(fileout,"EXTNAME",extname,"name of the binary extension")
+  fits_write_key(fileout,"EXTEND",extver,"Extension version");
+  fits_write_key(fileout,"OI_REVN",revision,"Revision number of the table definition");
+  fits_write_key(fileout,"DATE-OBS",date_obs,"UTC start date of observations");
+  fits_write_key(fileout,"ARRNAME",arrname,"(optional) Identifies corresponding OI_Array");
+  fits_write_key(fileout,"INSNAME",insname,"Identifies corresponding OI_WAVELENGTH");
+  fits_write_key(fileout,"EXTEND",extver,"Extension version");
+  fits_write_col(fileout, 1, 1, 1,  convert(Array{Int16},arrays[1]));
+  fits_write_col(fileout, 2, 1, 1,  convert(Array{Float64},arrays[2]));
+  fits_write_col(fileout, 3, 1, 1,  convert(Array{Float64},arrays[3]));
+  fits_write_col(fileout, 4, 1, 1,  convert(Array{Float64},arrays[4]));
+  fits_write_col(fileout, 5, 1, 1,  convert(Array{Float64},arrays[5]));
+  fits_write_col(fileout, 6, 1, 1,  convert(Array{Float64},arrays[6]));
+  fits_write_col(fileout, 7, 1, 1,  convert(Array{Float64},arrays[7]));
+  fits_write_col(fileout, 8, 1, 1,  convert(Array{Float64},arrays[8]));
+  fits_write_col(fileout, 9, 1, 1,  convert(Array{Int16},arrays[9]));
+  fits_write_col(fileout, 10, 1, 1, convert(Array{Bool,2},arrays[10]));
+ end
+
+function copy_oi_t3(fileout,hduin,arrays)
+#=
+/**
+ * Write OI_T3 fits binary tableDATE
+ *
+ * @param fptr     see cfitsio documentation
+ * @param vis2     data struct, see exchange.h
+ * @param extver   value for EXTVER keyword
+ * @param pStatus  pointer to status variable
+ *
+ * @return On error, returns non-zero cfitsio error code, and sets *pStatus
+ */
+=#
+  header=FITSIO.read_header(hduin);
+  nw=size(arrays[5])[1]
+  tfields = 14;  # mandatory columns */
+  zerotime = 0.0;
+  ttype = ["TARGET_ID", "TIME", "MJD", "INT_TIME",
+           "T3AMP", "T3AMPERR", "T3PHI","T3PHIERR",
+            "U1COORD", "V1COORD","U2COORD", "V2COORD",
+           "STA_INDEX", "FLAG"];
+  #tform = ["1I", "1D", "1D", "1D",
+    #       "8D", "8D", "8D", "8D",
+    #       "1D","1D","1D","1D","3I", "8L"];
+
+    tform = ["1I", "1D", "1D", "1D",
+            "$(nw)D", "$(nw)D", "$(nw)D", "$(nw)D",
+            "1D","1D","1D","1D","3I", "$(nw)L"];
+  tunit = ["\0", "s", "day", "s",
+           "\0", "\0", "deg", "deg",
+           "m", "m", "m", "m",
+           "\0", "\0"];
+
+  date_obs = header["DATE-OBS"]
+  arrname = header["ARRNAME"]
+  extname = header["EXTNAME"];
+  extver = header["EXTVER"]
+  revision = header["OI_REVN"]; #1 or 2 depending on which format XYZ
+  insname=header["INSNAME"]
+
+  coldefs =[(ttype[1],tform[1],tunit[1]),(ttype[2],tform[2],tunit[2]),(ttype[3],tform[3],tunit[3]),
+          (ttype[4],tform[4],tunit[4]),(ttype[5],tform[5],tunit[5]),(ttype[6],tform[6],tunit[6]),
+          (ttype[7],tform[7],tunit[7]),(ttype[8],tform[8],tunit[8]),(ttype[9],tform[9],tunit[9]),
+          (ttype[10],tform[10],tunit[10]),(ttype[11],tform[11],tunit[11]),(ttype[12],tform[12],tunit[12]),
+          (ttype[13],tform[13],tunit[13]),(ttype[14],tform[14],tunit[14])];
+  fits_create_binary_tbl(fileout,0,coldefs,extname);
+    fits_write_key(fileout,"EXTNAME",extname,"name of the binary extension")
+  fits_write_key(fileout,"OI_REVN",revision,"Revision number of the table definition");
+  fits_write_key(fileout,"DATE-OBS",date_obs,"UTC start date of observations");
+  fits_write_key(fileout,"ARRNAME",arrname,"(optional) Identifies corresponding OI_Array");
+  fits_write_key(fileout,"INSNAME",insname,"Identifies corresponding OI_WAVELENGTH");
+  fits_write_key(fileout,"EXTEND",extver,"Extension version");
+
+  #/* Write mandatory columns */
+  fits_write_col(fileout, 1, 1, 1,  convert(Array{Int16},arrays[1]));
+  fits_write_col(fileout, 2, 1, 1,  convert(Array{Float64},arrays[2]));
+  fits_write_col(fileout, 3, 1, 1,  convert(Array{Float64},arrays[3]));
+  fits_write_col(fileout, 4, 1, 1,  convert(Array{Float64},arrays[4]));
+  fits_write_col(fileout, 5, 1, 1,  convert(Array{Float64},arrays[5]));
+  fits_write_col(fileout, 6, 1, 1,  convert(Array{Float64},arrays[6]));
+  fits_write_col(fileout, 7, 1, 1,  convert(Array{Float64},arrays[7]));
+  fits_write_col(fileout, 8, 1, 1,  convert(Array{Float64},arrays[8]));
+  fits_write_col(fileout, 9, 1, 1,  convert(Array{Float64},arrays[9]));
+  fits_write_col(fileout, 10, 1, 1,  convert(Array{Float64},arrays[10]));
+  fits_write_col(fileout, 11, 1, 1,  convert(Array{Float64},arrays[11]));
+  fits_write_col(fileout, 12, 1, 1,  convert(Array{Float64},arrays[12]))
+  fits_write_col(fileout, 13, 1, 1,  convert(Array{Int16},arrays[13]));
+  fits_write_col(fileout, 14, 1, 1, convert(Array{Bool,2},arrays[14]));
+ end


### PR DESCRIPTION
Adding two files, write_oifits_obs.jl and simulate_obs.jl. These allow users to copy oifits observations and use input image to simulate observations. 